### PR TITLE
Remove unnecessary 'idris2' dependency

### DIFF
--- a/hashable.ipkg
+++ b/hashable.ipkg
@@ -2,7 +2,7 @@ package hashable
 
 version = 0.1.0
 
-depends = idris2, contrib
+depends = contrib
 
 sourcedir = "src"
 


### PR DESCRIPTION
It seems this dependency is no longer necessary - I don't have it installed on my system, but the project still builds fine without it.