### PR TITLE
implement `Hashable` for `Nat`

### DIFF
--- a/src/Data/Hashable.idr
+++ b/src/Data/Hashable.idr
@@ -54,6 +54,11 @@ Hashable Int where
     hashWithSalt = defaultHashWithSalt
 
 export
+Hashable Nat where
+    hash = cast
+    hashWithSalt = defaultHashWithSalt
+
+export
 Hashable Char where
     hash = cast . ord
     hashWithSalt = defaultHashWithSalt


### PR DESCRIPTION
I notice The haskell version handles the size of `Nat`s. Are Idris `Nat`s infinite width? I notice you've got an implementation for `Int` which suggests to me this would be OK but I'd be guessing