### PR TITLE
implement `Hashable` for `Pair`

### DIFF
--- a/src/Data/Hashable.idr
+++ b/src/Data/Hashable.idr
@@ -124,6 +124,10 @@ Hashable Bool where
     hashWithSalt = defaultHashWithSalt hash
 
 export
+(Hashable a, Hashable b) => Hashable (a, b) where
+    hashWithSalt salt (a, b) = salt `hashWithSalt` a `hashWithSalt` b
+
+export
 Hashable a => Hashable (Maybe a) where
     hashWithSalt salt Nothing = hashWithSalt salt 0
     hashWithSalt salt (Just x) = hashWithSalt salt 1 `hashWithSalt` x


### PR DESCRIPTION
Curiously, this also makes a whole load of other `Hashable` implementations much easier as you can replace chains of `hashwithSalt` with tuples e.g.
```
export
Hashable a => Hashable (List a) where
    hashWithSalt salt [] = hashWithSalt salt 0
    hashWithSalt salt (x :: xs) =
        salt
            `hashWithSalt` 1
            `hashWithSalt` x
            `hashWithSalt` xs
```
can be written
```
export
Hashable a => Hashable (List a) where
    hashWithSalt salt [] = hashWithSalt salt 0
    hashWithSalt salt (x :: xs) = hashWithSalt salt (1, x, xs)
```