### PR TITLE
[ cleanup ] Remove contrib

### DIFF
--- a/hashable.ipkg
+++ b/hashable.ipkg
@@ -2,7 +2,7 @@ package hashable
 
 version = 0.1.0
 
-depends = contrib
+depends = base 
 
 sourcedir = "src"
 


### PR DESCRIPTION
This PR removes the dependency on `contrib`.