### PR TITLE
[ fix ] Use `unpack` instead of `fastUnpack`

### DIFF
--- a/src/Data/Hashable.idr
+++ b/src/Data/Hashable.idr
@@ -109,7 +109,7 @@ Hashable Nat where
 
 export
 Hashable String where
-    hashWithSalt salt str = finalise (foldl step (salt, 0) $ fastUnpack str)
+    hashWithSalt salt str = finalise (foldl step (salt, 0) $ unpack str)
       where
         step : (Bits64, Bits64) -> Char -> (Bits64, Bits64)
         step (s, l) x = (hashWithSalt s x, l + 1)


### PR DESCRIPTION
Being an FFI function, `fastUnpack` can't be evaluated at compile time, making `Hashable` usage problematic (impossible, in case of `Hashable String`) in elaborator scripts.

Since there is a transform [rule](https://github.com/idris-lang/Idris2/blob/acde1c9260fffb140525fea191a17cd23368c61c/libs/prelude/Prelude/Types.idr#L888) `unpack = fastUnpack`, this change should not affect any code running in a non-compile-time context.